### PR TITLE
(#18) Support Python 3

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import json
 import sys
 
@@ -15,19 +17,19 @@ command_list.append('terminate_vpc')
 
 
 def print_usage():
-    print '#' * 80
-    print 'How to Play'
-    print
-    print '-' * 80
+    print('#' * 80)
+    print('How to Play')
+    print()
+    print('-' * 80)
     for cc in command_list:
-        print '    ./run.py ' + cc
-    print '-' * 80
-    print '    ./run.py [AWS CLI COMMAND]                 ' + \
-          '(ex: \'./run.py -- aws ec2 describe-instances\')'
-    print '    cd [EB DIR]; ../run.py [EB CLI COMMAND]    ' + \
-          '(ex: \'cd nova; ../run.py -- eb list --region ap-northeast-2\')'
-    print
-    print '#' * 80
+        print('    ./run.py ' + cc)
+    print('-' * 80)
+    print('    ./run.py [AWS CLI COMMAND]                 ' +
+          '(ex: \'./run.py -- aws ec2 describe-instances\')')
+    print('    cd [EB DIR]; ../run.py [EB CLI COMMAND]    ' +
+          '(ex: \'cd nova; ../run.py -- eb list --region ap-northeast-2\')')
+    print()
+    print('#' * 80)
 
 
 if __name__ == "__main__":
@@ -45,14 +47,14 @@ if __name__ == "__main__":
         aws_cli = AWSCli()
         result = aws_cli.run(args[2:], ignore_error=True)
         if type(result) == dict:
-            print json.dumps(result, sort_keys=True, indent=4)
+            print(json.dumps(result, sort_keys=True, indent=4))
         else:
-            print result
+            print(result)
         sys.exit(0)
     elif command == 'eb':
         aws_cli = AWSCli()
         result = aws_cli.run_eb(args[2:], ignore_error=True)
-        print result
+        print(result)
         sys.exit(0)
 
     if len(args) != 2:

--- a/run_common.py
+++ b/run_common.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import json
 import os
 import re
@@ -9,19 +11,23 @@ from optparse import OptionParser
 
 from env import env
 
+try:
+    input = raw_input
+except NameError:
+    pass
+
 
 def _confirm_phase():
     phase = env['common']['PHASE']
-    print 'Your current environment values are below'
-    print '-' * 80
-    print '\tPHASE            : \'%s\'' % phase
-    print '\tCNAME of Nova    : \'%s\'' % env['nova']['CNAME']
-    print '-' * 80
-    sys.stdout.write('Please type in the name of phase \'%s\' to confirm: ' % phase)
+    print('Your current environment values are below')
+    print('-' * 80)
+    print('\tPHASE            : \'%s\'' % phase)
+    print('\tCNAME of Nova    : \'%s\'' % env['nova']['CNAME'])
+    print('-' * 80)
 
-    answer = raw_input()
+    answer = input('Please type in the name of phase \'%s\' to confirm: ' % phase)
     if answer != phase:
-        print 'The execution is canceled.'
+        print('The execution is canceled.')
         sys.exit(0)
 
 
@@ -49,15 +55,16 @@ class AWSCli:
 
     def _run(self, args, cwd=None, ignore_error=None):
         if ignore_error:
-            print '\n>> command(ignore error):',
+            print('\n>> command(ignore error):', end=" ")
         else:
-            print '\n>> command:',
-        print ' '.join(args)
+            print('\n>> command:', end=" ")
+        print(' '.join(args))
         result, error = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                          cwd=cwd, env=self.env).communicate()
+        result = result.decode('utf-8')
 
         if error:
-            print error
+            print(error)
             if not ignore_error:
                 raise Exception()
 
@@ -111,7 +118,7 @@ class AWSCli:
             if count == 0:
                 break
 
-            print 'terminating the eb... (elapsed time: \'%d\' seconds)' % elapsed_time
+            print('terminating the eb... (elapsed time: \'%d\' seconds)' % elapsed_time)
             time.sleep(5)
             elapsed_time += 5
 
@@ -129,7 +136,7 @@ class AWSCli:
             if count == 0:
                 break
 
-            print 'deleting the nat gateway... (elapsed time: \'%d\' seconds)' % elapsed_time
+            print('deleting the nat gateway... (elapsed time: \'%d\' seconds)' % elapsed_time)
             time.sleep(5)
             elapsed_time += 5
 
@@ -151,13 +158,13 @@ def parse_args(require_arg=False):
 
 
 def print_message(message):
-    print '*' * 80
-    print message + '\n'
+    print('*' * 80)
+    print(message + '\n')
 
 
 def print_session(message):
-    print '#' * 80 + '\n' + '#' * 80
-    print '\n\t[ ' + message + ' ]\n\n'
+    print('#' * 80 + '\n' + '#' * 80)
+    print('\n\t[ ' + message + ' ]\n\n')
 
 
 def read_file(file_path):

--- a/run_create_nova.py
+++ b/run_create_nova.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import json
 import os
 import subprocess
@@ -53,7 +55,7 @@ print_message('get vpc id')
 eb_vpc_id = aws_cli.get_vpc_id()
 
 if not eb_vpc_id:
-    print 'ERROR!!! No VPC found'
+    print('ERROR!!! No VPC found')
     raise Exception()
 
 ################################################################################
@@ -143,7 +145,7 @@ for r in result['Environments']:
         if r['Status'] == 'Terminated':
             continue
         elif r['Status'] != 'Ready':
-            print 'previous version is not ready.'
+            print('previous version is not ready.')
             raise Exception()
 
         eb_environment_name_old = r['EnvironmentName']
@@ -154,8 +156,8 @@ for r in result['Environments']:
 print_message('create nova')
 
 tags = list()
-tags.append('git_hash_johanna=%s' % git_hash_johanna)
-tags.append('git_hash_nova=%s' % git_hash_nova)
+tags.append('git_hash_johanna=%s' % git_hash_johanna.decode('utf-8'))
+tags.append('git_hash_nova=%s' % git_hash_nova.decode('utf-8'))
 
 cmd = ['create', eb_environment_name]
 cmd += ['--cname', cname]
@@ -179,13 +181,13 @@ while True:
     result = aws_cli.run(cmd)
 
     ee = result['Environments'][0]
-    print json.dumps(ee, sort_keys=True, indent=4)
+    print(json.dumps(ee, sort_keys=True, indent=4))
     if ee.get('Health', '') == 'Green' \
             and ee.get('HealthStatus', '') == 'Ok' \
             and ee.get('Status', '') == 'Ready':
         break
 
-    print 'creating... (elapsed time: \'%d\' seconds)' % elapsed_time
+    print('creating... (elapsed time: \'%d\' seconds)' % elapsed_time)
     time.sleep(5)
     elapsed_time += 5
 

--- a/run_create_vpc.py
+++ b/run_create_vpc.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import sys
 
 from env import env
@@ -28,7 +30,7 @@ print_message('get vpc id')
 eb_vpc_id = aws_cli.get_vpc_id()
 if eb_vpc_id:
     print_message('VPC already exists')
-    print 'EB: %s \n' % eb_vpc_id
+    print('EB: %s \n' % eb_vpc_id)
     print_session('finish python code')
     sys.exit(0)
 

--- a/run_terminate_eb_old_environment.py
+++ b/run_terminate_eb_old_environment.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import time
 
 from env import env
@@ -32,16 +34,16 @@ def _is_old_environment(cname):
 
     # 'old_timestamp' MUST NOT be greater than current timestamp
     if old_timestamp > timestamp:
-        print 'wrong old timestamp (too big)'
+        print('wrong old timestamp (too big)')
         return False
 
     # 'old_timestamp' MUST NOT be less than timestamp of '2016-01-01 00:00:00'.
     if old_timestamp < 1451606400:
-        print 'wrong old timestamp (too small)'
+        print('wrong old timestamp (too small)')
         return False
 
     if old_timestamp + max_age_seconds > timestamp:
-        print 'skip this time'
+        print('skip this time')
         return False
 
     return True
@@ -66,11 +68,11 @@ for r in result['Environments']:
     if 'CNAME' not in r:
         continue
 
-    print ''
-    print 'EnvironmentName:', r['EnvironmentName']
-    print 'CNAME:', r['CNAME']
-    print 'Status:', r['Status']
-    print ''
+    print('')
+    print('EnvironmentName:', r['EnvironmentName'])
+    print('CNAME:', r['CNAME'])
+    print('Status:', r['Status'])
+    print('')
 
     if r['Status'] != 'Ready':
         continue

--- a/run_terminate_nova.py
+++ b/run_terminate_nova.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import time
 
 from env import env
@@ -48,6 +50,6 @@ while True:
     if count == 0:
         break
 
-    print 'deleting the environment... (elapsed time: \'%d\' seconds)' % elapsed_time
+    print('deleting the environment... (elapsed time: \'%d\' seconds)' % elapsed_time)
     time.sleep(5)
     elapsed_time += 5

--- a/run_terminate_vpc.py
+++ b/run_terminate_vpc.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 from env import env
 from run_common import AWSCli
 from run_common import print_message
@@ -67,7 +69,7 @@ for r in result['SecurityGroups']:
         continue
     if r['GroupName'] == 'default':
         continue
-    print 'delete security group (id: %s)' % r['GroupId']
+    print('delete security group (id: %s)' % r['GroupId'])
     cmd = ['ec2', 'delete-security-group']
     cmd += ['--group-id', r['GroupId']]
     aws_cli.run(cmd, ignore_error=True)
@@ -82,7 +84,7 @@ for r in result['RouteTables']:
         continue
     for route in r['Routes']:
         if route['DestinationCidrBlock'] == '0.0.0.0/0':
-            print 'delete route (route table id: %s)' % r['RouteTableId']
+            print('delete route (route table id: %s)' % r['RouteTableId'])
             cmd = ['ec2', 'delete-route']
             cmd += ['--route-table-id', r['RouteTableId']]
             cmd += ['--destination-cidr-block', '0.0.0.0/0']
@@ -99,8 +101,8 @@ for r in result['RouteTables']:
     for association in r['Associations']:
         if association['Main']:
             continue
-        print 'disassociate route table (route table id: %s, route table association id: %s)' % \
-              (r['RouteTableId'], association['RouteTableAssociationId'])
+        print('disassociate route table (route table id: %s, route table association id: %s)' %
+              (r['RouteTableId'], association['RouteTableAssociationId']))
         cmd = ['ec2', 'disassociate-route-table']
         cmd += ['--association-id', association['RouteTableAssociationId']]
         aws_cli.run(cmd, ignore_error=True)
@@ -115,7 +117,7 @@ for r in result['RouteTables']:
         continue
     if len(r['Associations']) != 0:
         continue
-    print 'delete route table (route table id: %s)' % r['RouteTableId']
+    print('delete route table (route table id: %s)' % r['RouteTableId'])
     cmd = ['ec2', 'delete-route-table']
     cmd += ['--route-table-id', r['RouteTableId']]
     aws_cli.run(cmd, ignore_error=True)
@@ -128,7 +130,7 @@ result = aws_cli.run(cmd, ignore_error=True)
 for r in result['NatGateways']:
     if r['VpcId'] != eb_vpc_id:
         continue
-    print 'delete nat gateway (nat gateway id: %s)' % r['NatGatewayId']
+    print('delete nat gateway (nat gateway id: %s)' % r['NatGatewayId'])
     cmd = ['ec2', 'delete-nat-gateway']
     cmd += ['--nat-gateway-id', r['NatGatewayId']]
     aws_cli.run(cmd, ignore_error=True)
@@ -144,7 +146,7 @@ print_message('release eip')
 cmd = ['ec2', 'describe-addresses']
 result = aws_cli.run(cmd, ignore_error=True)
 for r in result['Addresses']:
-    print 'release address (address id: %s)' % r['AllocationId']
+    print('release address (address id: %s)' % r['AllocationId'])
     cmd = ['ec2', 'release-address']
     cmd += ['--allocation-id', r['AllocationId']]
     aws_cli.run(cmd, ignore_error=True)
@@ -159,7 +161,7 @@ for r in result['InternetGateways']:
         continue
     if r['Attachments'][0]['VpcId'] != eb_vpc_id:
         continue
-    print 'detach internet gateway (internet gateway id: %s)' % r['InternetGatewayId']
+    print('detach internet gateway (internet gateway id: %s)' % r['InternetGatewayId'])
     cmd = ['ec2', 'detach-internet-gateway']
     cmd += ['--internet-gateway-id', r['InternetGatewayId']]
     cmd += ['--vpc-id', r['Attachments'][0]['VpcId']]
@@ -173,7 +175,7 @@ result = aws_cli.run(cmd, ignore_error=True)
 for r in result['InternetGateways']:
     if len(r['Attachments']) != 0:
         continue
-    print 'delete internet gateway (internet gateway id: %s)' % r['InternetGatewayId']
+    print('delete internet gateway (internet gateway id: %s)' % r['InternetGatewayId'])
     cmd = ['ec2', 'delete-internet-gateway']
     cmd += ['--internet-gateway-id', r['InternetGatewayId']]
     aws_cli.run(cmd, ignore_error=True)
@@ -186,7 +188,7 @@ result = aws_cli.run(cmd, ignore_error=True)
 for r in result['Subnets']:
     if r['VpcId'] != eb_vpc_id:
         continue
-    print 'delete subnet (subnet id: %s)' % r['SubnetId']
+    print('delete subnet (subnet id: %s)' % r['SubnetId'])
     cmd = ['ec2', 'delete-subnet']
     cmd += ['--subnet-id', r['SubnetId']]
     aws_cli.run(cmd, ignore_error=True)
@@ -195,7 +197,7 @@ for r in result['Subnets']:
 print_message('delete vpc')
 
 if eb_vpc_id:
-    print 'delete vpc (vpc id: %s)' % eb_vpc_id
+    print('delete vpc (vpc id: %s)' % eb_vpc_id)
     cmd = ['ec2', 'delete-vpc']
     cmd += ['--vpc-id', eb_vpc_id]
     aws_cli.run(cmd, ignore_error=True)


### PR DESCRIPTION
Fix the some codes for supporting python3
1. Use print function instead of print statement
2. There is no 'raw_input' function in python3. but just 'input' has
   same function of 'raw_input'. But, this is not same to 'input' function
   in python2. So, if 'raw_input' exists, bind it to 'input'.
3. The type of output of 'subprocess.Popen().communicate()[0]' is 'bytes'. In python2, 'bytes' is same to 'str', so there is no any problems. But, In python3, 'bytes' is not same to 'str'. So, some functions are not working with 'bytes' in python3. I resolved these problems by decoding the 'bytes' string with 'utf-8'.
